### PR TITLE
fix: hide password prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,12 +281,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "secured"
 version = "0.1.1"
 dependencies = [
  "clap",
+ "rpassword",
  "secured-enclave",
- "text_io",
 ]
 
 [[package]]
@@ -333,12 +354,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "text_io"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f0c8eb2ad70c12a6a69508f499b3051c924f4b1cfeae85bfad96e6bc5bba46"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ version = "0.1.0"
 version = "^4.0.0"
 features = ["derive"]
 
-[dependencies.text_io]
-version = "^0.1.12"
+[dependencies.rpassword]
+version = "^7.3.1"
 
 [[bin]]
 name = "secured"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
+use rpassword::prompt_password;
 use std::fs::{metadata, File};
 use std::io::{Read, Write};
-use text_io::read;
 
 use enclave::{Enclave, EncryptionKey};
 
@@ -122,9 +122,6 @@ fn get_file_as_byte_vec(filename: &String) -> Vec<u8> {
 fn get_password_or_prompt(password: Option<String>) -> String {
   match password {
     Some(password) => password,
-    None => {
-      println!("Enter password: ");
-      read!("{}\n")
-    }
+    None => prompt_password("Enter password: ").expect("Unable to read password"),
   }
 }


### PR DESCRIPTION
Password prompt should not show the password that is being typed by the user.