### PR TITLE
refactor: remove `Enclave` `NONCE_SIZE` generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main() {
 
    // Using Enclave for data encapsulation (&str metadata, 8-byte nonce)
    let enclave =
-      Enclave::<&str, 8>::from_plain_bytes("Some metadata", key.pubk, b"Some bytes to encrypt".to_vec())
+      Enclave::from_plain_bytes("Some metadata", key.pubk, b"Some bytes to encrypt".to_vec())
          .unwrap();
 
    // Get encrypted bytes (ciphertext)

--- a/benches/src/enclave.rs
+++ b/benches/src/enclave.rs
@@ -14,7 +14,7 @@ fn bench(c: &mut Criterion) {
     group.bench_with_input(BenchmarkId::new("encrypt", size), size, |b, &_size| {
       b.iter(|| {
         let buf = vec![0u8; *size];
-        Enclave::<&str, NONCE_SIZE>::from_plain_bytes("Metadata", key, buf)
+        Enclave::from_plain_bytes("Metadata", key, buf)
       });
     });
   }

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -2,7 +2,10 @@ pub mod errors;
 
 pub use errors::EnclaveError;
 use secured_cipher::{
-  chacha20::{core::{KEY_SIZE, NONCE_SIZE}, ChaCha20},
+  chacha20::{
+    core::{KEY_SIZE, NONCE_SIZE},
+    ChaCha20,
+  },
   random_bytes, Cipher,
 };
 
@@ -190,8 +193,7 @@ mod tests {
     fn it_should_serialize_and_deserialize_to_bytes() {
       let key: Key<32, 16> = Key::new(b"my password", 10_000);
       let bytes = [0u8, 1u8, 2u8, 3u8, 4u8].to_vec();
-      let enclave =
-        Enclave::from_plain_bytes([0_u8, 1_u8], key.pubk, bytes.clone()).unwrap();
+      let enclave = Enclave::from_plain_bytes([0_u8, 1_u8], key.pubk, bytes.clone()).unwrap();
 
       let serialized: Vec<u8> = enclave.clone().into();
       let deserialized = Enclave::try_from(serialized).unwrap();

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -2,7 +2,7 @@ pub mod errors;
 
 pub use errors::EnclaveError;
 use secured_cipher::{
-  chacha20::{core::KEY_SIZE, ChaCha20},
+  chacha20::{core::{KEY_SIZE, NONCE_SIZE}, ChaCha20},
   random_bytes, Cipher,
 };
 
@@ -14,7 +14,7 @@ use secured_cipher::{
 /// # Type Parameters
 /// * `T`: The type of metadata associated with the encrypted data.
 #[derive(Debug, Clone)]
-pub struct Enclave<T, const NONCE_SIZE: usize> {
+pub struct Enclave<T> {
   /// Metadata associated with the encrypted data.
   pub metadata: T,
 
@@ -25,7 +25,7 @@ pub struct Enclave<T, const NONCE_SIZE: usize> {
   nonce: [u8; NONCE_SIZE],
 }
 
-impl<T, const NONCE_SIZE: usize> Enclave<T, NONCE_SIZE> {
+impl<T> Enclave<T> {
   /// Creates a new `Enclave` instance from unencrypted data.
   ///
   /// # Arguments
@@ -66,7 +66,7 @@ impl<T, const NONCE_SIZE: usize> Enclave<T, NONCE_SIZE> {
   }
 }
 
-impl<T, const NONCE_SIZE: usize> From<Enclave<T, NONCE_SIZE>> for Vec<u8>
+impl<T> From<Enclave<T>> for Vec<u8>
 where
   T: TryFrom<Vec<u8>> + Into<Vec<u8>>,
 {
@@ -77,7 +77,7 @@ where
   ///
   /// # Returns
   /// A `Vec<u8>` representing the serialized enclave.
-  fn from(enclave: Enclave<T, NONCE_SIZE>) -> Vec<u8> {
+  fn from(enclave: Enclave<T>) -> Vec<u8> {
     let mut bytes: Vec<u8> = vec![];
     let metadata_bytes = enclave.metadata.into();
 
@@ -90,7 +90,7 @@ where
   }
 }
 
-impl<T, const NONCE_SIZE: usize> TryFrom<Vec<u8>> for Enclave<T, NONCE_SIZE>
+impl<T> TryFrom<Vec<u8>> for Enclave<T>
 where
   T: TryFrom<Vec<u8>> + Into<Vec<u8>>,
 {
@@ -121,7 +121,7 @@ where
   }
 }
 
-impl<T, const NONCE_SIZE: usize> PartialEq for Enclave<T, NONCE_SIZE>
+impl<T> PartialEq for Enclave<T>
 where
   T: PartialEq + TryFrom<Vec<u8>> + Into<Vec<u8>>,
 {
@@ -152,7 +152,7 @@ mod tests {
       let key: Key<32, 16> = Key::new(b"my password", 10_000);
       let bytes = [0u8, 1u8, 2u8, 3u8, 4u8].to_vec();
 
-      let safe = Enclave::<&str, 8>::from_plain_bytes("metadata", key.pubk, bytes);
+      let safe = Enclave::from_plain_bytes("metadata", key.pubk, bytes);
 
       assert!(safe.is_ok());
       assert_eq!(safe.unwrap().metadata, "metadata");
@@ -166,7 +166,7 @@ mod tests {
     fn it_should_decrypt_enclave() {
       let key: Key<32, 16> = Key::new(b"my password", 10_000);
       let bytes = [0u8, 1u8, 2u8, 3u8, 4u8].to_vec();
-      let safe = Enclave::<&str, 8>::from_plain_bytes("metadata", key.pubk, bytes.clone()).unwrap();
+      let safe = Enclave::from_plain_bytes("metadata", key.pubk, bytes.clone()).unwrap();
 
       let decrypted_bytes = safe.decrypt(key.pubk);
 
@@ -178,7 +178,7 @@ mod tests {
     fn it_should_fail_with_wrong_key() {
       let key: Key<32, 16> = Key::new(b"my password", 10_000);
       let bytes = [0u8, 1u8, 2u8, 3u8, 4u8].to_vec();
-      let safe = Enclave::<&str, 8>::from_plain_bytes("metadata", key.pubk, bytes.clone()).unwrap();
+      let safe = Enclave::from_plain_bytes("metadata", key.pubk, bytes.clone()).unwrap();
       let wrong_key: Key<32, 16> = Key::new(b"my wrong password", 10_000);
 
       let decrypted_bytes = safe.decrypt(wrong_key.pubk).unwrap();
@@ -191,7 +191,7 @@ mod tests {
       let key: Key<32, 16> = Key::new(b"my password", 10_000);
       let bytes = [0u8, 1u8, 2u8, 3u8, 4u8].to_vec();
       let enclave =
-        Enclave::<[u8; 2], 8>::from_plain_bytes([0_u8, 1_u8], key.pubk, bytes.clone()).unwrap();
+        Enclave::from_plain_bytes([0_u8, 1_u8], key.pubk, bytes.clone()).unwrap();
 
       let serialized: Vec<u8> = enclave.clone().into();
       let deserialized = Enclave::try_from(serialized).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub use cipher;
 ///     let key: Key<32, 16> = Key::new(b"my password", 1_000);
 ///
 ///     // Encrypt data: Utilize the Enclave to securely encrypt data along with metadata.
-///     let enclave = Enclave::<&str, 8>::from_plain_bytes("some metadata", key.pubk, b"some bytes to encrypt".to_vec()).unwrap();
+///     let enclave = Enclave::from_plain_bytes("some metadata", key.pubk, b"some bytes to encrypt".to_vec()).unwrap();
 ///   
 ///     // Decrypt data: Recover the original bytes from the encrypted enclave.
 ///     let recovered_bytes = enclave.decrypt(key.pubk);

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,8 +80,7 @@ fn encrypt_file(password: &String, filename: &String) {
 /// * `filename` - The name of the file to be decrypted.
 fn decrypt_file(password: &String, filename: &String) {
   let encrypted_bytes = get_file_as_byte_vec(filename);
-  let enclave = Enclave::try_from(encrypted_bytes)
-    .expect("Unable to deserialize enclave");
+  let enclave = Enclave::try_from(encrypted_bytes).expect("Unable to deserialize enclave");
   let encryption_key: Key<32, 16> = Key::with_salt(password.as_bytes(), enclave.metadata, 900_000);
   let recovered_bytes = enclave
     .decrypt(encryption_key.pubk)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use rpassword::prompt_password;
 use std::fs::{metadata, File};
 use std::io::{Read, Write};
 
-use cipher::{chacha20::NONCE_SIZE, Key};
+use cipher::Key;
 use enclave::Enclave;
 
 /// Defines command line subcommands for the application.
@@ -57,7 +57,7 @@ fn main() {
 /// * `filename` - The name of the file to be encrypted.
 fn encrypt_file(password: &String, filename: &String) {
   let encryption_key: Key<32, 16> = Key::new(password.as_bytes(), 900_000);
-  let enclave = Enclave::<[u8; 16], NONCE_SIZE>::from_plain_bytes(
+  let enclave = Enclave::from_plain_bytes(
     encryption_key.salt,
     encryption_key.pubk,
     get_file_as_byte_vec(filename),
@@ -80,7 +80,7 @@ fn encrypt_file(password: &String, filename: &String) {
 /// * `filename` - The name of the file to be decrypted.
 fn decrypt_file(password: &String, filename: &String) {
   let encrypted_bytes = get_file_as_byte_vec(filename);
-  let enclave = Enclave::<[u8; 16], NONCE_SIZE>::try_from(encrypted_bytes)
+  let enclave = Enclave::try_from(encrypted_bytes)
     .expect("Unable to deserialize enclave");
   let encryption_key: Key<32, 16> = Key::with_salt(password.as_bytes(), enclave.metadata, 900_000);
   let recovered_bytes = enclave


### PR DESCRIPTION
Remove previously introduced generic. This is being removed because the `ChaCha20` algorithm only supports 8-byte nonces.

I'll introduce in a separate PR an implementation of `XChaCha20`, which uses 12-byte nonces (4 more bytes are taken from the counter - indeed, `XChaCha20` can decrypt smaller amounts of data compared to `ChaCha20`).